### PR TITLE
fix: remove closing PHP tag to avoid header output warnings

### DIFF
--- a/backend/lib/Util.php
+++ b/backend/lib/Util.php
@@ -35,6 +35,3 @@ class Util {
         return ((int)$m[1]) * 3600 + ((int)$m[2]) * 60 + (float)$m[3];
     }
 }
-
-?>
-


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the closing PHP tag in backend/lib/Util.php to prevent accidental whitespace output and “headers already sent” warnings.

<!-- End of auto-generated description by cubic. -->

